### PR TITLE
Fix the translator not being used properly in the notifications

### DIFF
--- a/js/src/forum/components/UserSuspendedNotification.js
+++ b/js/src/forum/components/UserSuspendedNotification.js
@@ -13,12 +13,11 @@ export default class UserSuspendedNotification extends Notification {
 
   content() {
     const notification = this.props.notification;
-    const actor = notification.sender();
     const suspendUntil = notification.content();
     const timeReadable = moment(suspendUntil.date).from(notification.time(), true);
 
-    return app.translator.transChoice('flarum-suspend.forum.notifications.user_suspended_text', {
-      actor,
+    return app.translator.trans('flarum-suspend.forum.notifications.user_suspended_text', {
+      user: notification.sender(),
       timeReadable,
     });
   }

--- a/js/src/forum/components/UserUnsuspendedNotification.js
+++ b/js/src/forum/components/UserUnsuspendedNotification.js
@@ -14,7 +14,7 @@ export default class UserUnsuspendedNotification extends Notification {
   content() {
     const notification = this.props.notification;
 
-  return app.translator.trans('flarum-suspend.forum.notifications.user_unsuspended_text', {
+    return app.translator.trans('flarum-suspend.forum.notifications.user_unsuspended_text', {
       user: notification.sender(),
     });
   }

--- a/js/src/forum/components/UserUnsuspendedNotification.js
+++ b/js/src/forum/components/UserUnsuspendedNotification.js
@@ -13,10 +13,9 @@ export default class UserUnsuspendedNotification extends Notification {
 
   content() {
     const notification = this.props.notification;
-    const actor = notification.sender();
 
-    return app.translator.transChoice('flarum-suspend.forum.notifications.user_unsuspended_text', {
-      actor,
+  return app.translator.trans('flarum-suspend.forum.notifications.user_unsuspended_text', {
+      user: notification.sender(),
     });
   }
 }


### PR DESCRIPTION
This PR:
- Changes `.transChoice` to `.trans`
- Sets the actor to the translation `user` property, instead of `actor`

Related to #11.