### PR TITLE
Adds attribute mutation if suspended.

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -39,14 +39,17 @@ return [
         ->type(UserSuspendedBlueprint::class, BasicUserSerializer::class, ['alert', 'email'])
         ->type(UserUnsuspendedBlueprint::class, BasicUserSerializer::class, ['alert', 'email']),
 
+    (new Extend\Event())
+        ->listen(Saving::class, Listener\SaveSuspensionToDatabase::class)
+        ->listen(Saving::class, Listener\PreventAttributesMutations::class)
+        ->listen(Suspended::class, Listener\SendNotificationWhenUserIsSuspended::class)
+        ->listen(Unsuspended::class, Listener\SendNotificationWhenUserIsUnsuspended::class),
+
+    (new Extend\User)
+        ->permissionGroups(Listener\RevokeAccessFromSuspendedUsers::class),
+
     function (Dispatcher $events) {
         $events->subscribe(Listener\AddUserSuspendAttributes::class);
-        $events->subscribe(Listener\RevokeAccessFromSuspendedUsers::class);
-
-        $events->listen(Saving::class, Listener\SaveSuspensionToDatabase::class);
-
-        $events->listen(Suspended::class, Listener\SendNotificationWhenUserIsSuspended::class);
-        $events->listen(Unsuspended::class, Listener\SendNotificationWhenUserIsUnsuspended::class);
 
         $events->subscribe(Access\UserPolicy::class);
 

--- a/src/Listener/PreventAttributesMutations.php
+++ b/src/Listener/PreventAttributesMutations.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Flarum\Suspend\Listener;
+
+use Flarum\User\Event\Saving;
+use Flarum\User\Exception\PermissionDeniedException;
+
+class PreventAttributesMutations
+{
+    public function handle(Saving $event)
+    {
+        if (! $event->user->suspended_until) return;
+
+        if ($event->user->id === $event->actor->id) {
+            throw new PermissionDeniedException;
+        }
+    }
+}

--- a/src/Listener/PreventAttributesMutations.php
+++ b/src/Listener/PreventAttributesMutations.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
 namespace Flarum\Suspend\Listener;
 
 use Flarum\User\Event\Saving;
@@ -9,7 +16,9 @@ class PreventAttributesMutations
 {
     public function handle(Saving $event)
     {
-        if (! $event->user->suspended_until) return;
+        if (! $event->user->suspended_until) {
+            return;
+        }
 
         if ($event->user->id === $event->actor->id) {
             throw new PermissionDeniedException;

--- a/src/Listener/RevokeAccessFromSuspendedUsers.php
+++ b/src/Listener/RevokeAccessFromSuspendedUsers.php
@@ -10,29 +10,17 @@
 namespace Flarum\Suspend\Listener;
 
 use Carbon\Carbon;
-use Flarum\Event\PrepareUserGroups;
 use Flarum\Group\Group;
-use Illuminate\Contracts\Events\Dispatcher;
+use Flarum\User\User;
 
 class RevokeAccessFromSuspendedUsers
 {
-    /**
-     * @param Dispatcher $events
-     */
-    public function subscribe(Dispatcher $events)
+    public function __invoke(User $user, array $groupIds)
     {
-        $events->listen(PrepareUserGroups::class, [$this, 'prepareUserGroups']);
-    }
-
-    /**
-     * @param PrepareUserGroups $event
-     */
-    public function prepareUserGroups(PrepareUserGroups $event)
-    {
-        $suspendedUntil = $event->user->suspended_until;
+        $suspendedUntil = $user->suspended_until;
 
         if ($suspendedUntil && $suspendedUntil->gt(Carbon::now())) {
-            $event->groupIds = [Group::GUEST_ID];
+            return [Group::GUEST_ID];
         }
     }
 }


### PR DESCRIPTION
Fixes flarum/core#2136.

This PR adds two new listeners and refactors some code to new extenders.

- The PreventAttributesMutations listener prevents changes of any attributes if these changes are made by the actual user and the user is suspended. This is helpful for the bio for instance.
- The PreventAvatarMutations listener prevents changing the avatar.

I'm aware this is not what has been discussed in the issue. But this is a very sane solution to prevent abuse across other extensions.