### PR TITLE
Fix suspended notification not showing correct suspension length

### DIFF
--- a/js/src/forum/components/UserSuspendedNotification.js
+++ b/js/src/forum/components/UserSuspendedNotification.js
@@ -12,7 +12,7 @@ export default class UserSuspendedNotification extends Notification {
   content() {
     const notification = this.attrs.notification;
     const suspendedUntil = notification.content();
-    const timeReadable = dayjs(suspendedUntil.date).from(notification.createdAt(), true);
+    const timeReadable = dayjs(suspendedUntil).from(notification.createdAt(), true);
 
     return app.translator.trans('flarum-suspend.forum.notifications.user_suspended_text', {
       user: notification.fromUser(),


### PR DESCRIPTION
**Fixes flarum/core#2458**

**Why did this break?**
No idea. This code hasn't changed in 4 years. 

Only thing I can think of is that the returned value was previously a Carbon object, thus needing to access it like JSON after it was serialized.
It is now a string, so the existing code no longer works.