### PR TITLE
Prevent adding suspension with date in the past

### DIFF
--- a/src/SuspendValidator.php
+++ b/src/SuspendValidator.php
@@ -17,6 +17,6 @@ class SuspendValidator extends AbstractValidator
      * {@inheritdoc}
      */
     protected $rules = [
-        'suspendedUntil' => ['nullable', 'date'],
+        'suspendedUntil' => ['nullable', 'date', 'after:today'],
     ];
 }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes issue identified in QA**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Don't allow a date in the past to be used as a new suspension end date. Previously, if this was done, user would see a suspension notification without actually being suspended.

![](https://user-images.githubusercontent.com/7406822/136243557-12c77949-c852-463b-8018-79872142f5cc.png)

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Does this change any existing behaviour?

Not tested locally. Will do so after some more QA checking.

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).

