### PR TITLE
Display suspension to user

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -63,5 +63,5 @@ return [
         ->addGambit(SuspendedFilterGambit::class),
 
     (new Extend\View())
-        ->namespace('flarum-suspend', __DIR__.'views'),
+        ->namespace('flarum-suspend', __DIR__.'/views'),
 ];

--- a/extend.php
+++ b/extend.php
@@ -60,5 +60,8 @@ return [
         ->addFilter(SuspendedFilterGambit::class),
 
     (new Extend\SimpleFlarumSearch(UserSearcher::class))
-        ->addGambit(SuspendedFilterGambit::class)
+        ->addGambit(SuspendedFilterGambit::class),
+
+    (new Extend\View())
+        ->namespace('flarum-suspend', __DIR__.'views'),
 ];

--- a/js/src/forum/checkForSuspension.ts
+++ b/js/src/forum/checkForSuspension.ts
@@ -7,7 +7,7 @@ export default function () {
     if (app.session.user) {
       const message = app.session.user.suspendMessage();
       const until = app.session.user.suspendedUntil();
-      const alreadyDisplayed = localStorage.getItem(localStorageKey()) === until;
+      const alreadyDisplayed = localStorage.getItem(localStorageKey()) === until.getTime().toString();
 
       if (message && !alreadyDisplayed) {
         app.modal.show(SuspensionInfoModal, { message, until });

--- a/js/src/forum/checkForSuspension.ts
+++ b/js/src/forum/checkForSuspension.ts
@@ -1,16 +1,19 @@
 import app from 'flarum/forum/app';
 import SuspensionInfoModal from './components/SuspensionInfoModal';
+import { localStorageKey } from './helpers/suspensionHelper';
 
 export default function () {
-  return new Promise(() => {
-    setTimeout(() => {
-      if (app.session.user) {
-        const message = app.session.user.suspendMessage();
-        const until = app.session.user.suspendedUntil();
-        if (message) {
-          app.modal.show(SuspensionInfoModal, { message, until });
-        }
+  return setTimeout(() => {
+    if (app.session.user) {
+      const message = app.session.user.suspendMessage();
+      const until = app.session.user.suspendedUntil();
+      const alreadyDisplayed = localStorage.getItem(localStorageKey()) === until;
+
+      if (message && !alreadyDisplayed) {
+        app.modal.show(SuspensionInfoModal, { message, until });
+      } else if (!until && localStorage.getItem(localStorageKey())) {
+        localStorage.removeItem(localStorageKey());
       }
-    }, 1000);
-  });
+    }
+  }, 0);
 }

--- a/js/src/forum/checkForSuspension.ts
+++ b/js/src/forum/checkForSuspension.ts
@@ -1,0 +1,16 @@
+import app from 'flarum/forum/app';
+import SuspensionInfoModal from './components/SuspensionInfoModal';
+
+export default function () {
+  return new Promise(() => {
+    setTimeout(() => {
+      if (app.session.user) {
+        const message = app.session.user.suspendMessage();
+        const until = app.session.user.suspendedUntil();
+        if (message) {
+          app.modal.show(SuspensionInfoModal, { message, until });
+        }
+      }
+    }, 1000);
+  });
+}

--- a/js/src/forum/compat.js
+++ b/js/src/forum/compat.js
@@ -1,0 +1,13 @@
+import SuspendUserModal from './components/SuspendUserModal';
+import SuspensionInfoModal from './components/SuspensionInfoModal';
+import UserSuspendedNotification from './components/UserSuspendedNotification';
+import UserUnsuspendedNotification from './components/UserUnsuspendedNotification';
+import checkForSuspension from './checkForSuspension';
+
+export default {
+  'suspend/components/suspendUserModal': SuspendUserModal,
+  'suspend/components/suspensionInfoModal': SuspensionInfoModal,
+  'suspend/components/UserSuspendedNotification': UserSuspendedNotification,
+  'suspend/components/UserUnsuspendedNotification': UserUnsuspendedNotification,
+  'suspend/checkForSuspension': checkForSuspension,
+};

--- a/js/src/forum/components/SuspendUserModal.js
+++ b/js/src/forum/components/SuspendUserModal.js
@@ -5,6 +5,7 @@ import Button from 'flarum/components/Button';
 import Stream from 'flarum/utils/Stream';
 import withAttr from 'flarum/utils/withAttr';
 import ItemList from 'flarum/common/utils/ItemList';
+import { getPermanentSuspensionDate } from '../helpers/suspensionHelper';
 
 export default class SuspendUserModal extends Modal {
   oninit(vnode) {
@@ -131,7 +132,7 @@ export default class SuspendUserModal extends Modal {
     let suspendedUntil = null;
     switch (this.status()) {
       case 'indefinitely':
-        suspendedUntil = new Date('2038-01-01');
+        suspendedUntil = getPermanentSuspensionDate();
         break;
 
       case 'limited':

--- a/js/src/forum/components/SuspendUserModal.js
+++ b/js/src/forum/components/SuspendUserModal.js
@@ -107,7 +107,12 @@ export default class SuspendUserModal extends Modal {
       'reason',
       <label>
         {app.translator.trans('flarum-suspend.forum.suspend_user.reason')}
-        <textarea className="FormControl" bidi={this.reason} placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')} rows="2" />
+        <textarea
+          className="FormControl"
+          bidi={this.reason}
+          placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')}
+          rows="2"
+        />
       </label>,
       70
     );
@@ -116,7 +121,12 @@ export default class SuspendUserModal extends Modal {
       'message',
       <label>
         {app.translator.trans('flarum-suspend.forum.suspend_user.display_message')}
-        <textarea className="FormControl" bidi={this.message} placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')} rows="2" />
+        <textarea
+          className="FormControl"
+          bidi={this.message}
+          placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')}
+          rows="2"
+        />
       </label>,
       60
     );

--- a/js/src/forum/components/SuspendUserModal.js
+++ b/js/src/forum/components/SuspendUserModal.js
@@ -43,9 +43,6 @@ export default class SuspendUserModal extends Modal {
         <div className="Form">
           <div className="Form-group">
             <label>{app.translator.trans('flarum-suspend.forum.suspend_user.status_heading')}</label>
-            <div>{this.radioItems().toArray()}</div>
-          </div>
-          <div className="Form-group">
             <div>{this.formItems().toArray()}</div>
           </div>
 
@@ -113,8 +110,17 @@ export default class SuspendUserModal extends Modal {
     const items = new ItemList();
 
     items.add(
+      'radioItems',
+      <div className='Form-group'>
+        {this.radioItems().toArray()}
+      </div>,
+      100
+    );
+
+    items.add(
       'reason',
-      <label>
+      <div className='Form-group'>
+        <label>
         {app.translator.trans('flarum-suspend.forum.suspend_user.reason')}
         <textarea
           className="FormControl"
@@ -122,13 +128,15 @@ export default class SuspendUserModal extends Modal {
           placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')}
           rows="2"
         />
-      </label>,
+      </label>
+      </div>,
       90
     );
 
     items.add(
       'message',
-      <label>
+      <div className='Form-group'>
+        <label>
         {app.translator.trans('flarum-suspend.forum.suspend_user.display_message')}
         <textarea
           className="FormControl"
@@ -136,7 +144,8 @@ export default class SuspendUserModal extends Modal {
           placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')}
           rows="2"
         />
-      </label>,
+      </label>
+      </div>,
       80
     );
 

--- a/js/src/forum/components/SuspendUserModal.js
+++ b/js/src/forum/components/SuspendUserModal.js
@@ -45,7 +45,7 @@ export default class SuspendUserModal extends Modal {
             <label>{app.translator.trans('flarum-suspend.forum.suspend_user.status_heading')}</label>
             <div>{this.radioItems().toArray()}</div>
           </div>
-          <div className='Form-group'>
+          <div className="Form-group">
             <div>{this.formItems().toArray()}</div>
           </div>
 

--- a/js/src/forum/components/SuspendUserModal.js
+++ b/js/src/forum/components/SuspendUserModal.js
@@ -106,7 +106,7 @@ export default class SuspendUserModal extends Modal {
       'reason',
       <label>
         {app.translator.trans('flarum-suspend.forum.suspend_user.reason')}
-        <textarea className="FormControl" bidi={this.reason} placeholder="optional" rows="2" />
+        <textarea className="FormControl" bidi={this.reason} placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')} rows="2" />
       </label>,
       70
     );
@@ -115,7 +115,7 @@ export default class SuspendUserModal extends Modal {
       'message',
       <label>
         {app.translator.trans('flarum-suspend.forum.suspend_user.display_message')}
-        <textarea className="FormControl" bidi={this.message} placeholder="optional" rows="2" />
+        <textarea className="FormControl" bidi={this.message} placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')} rows="2" />
       </label>,
       60
     );

--- a/js/src/forum/components/SuspendUserModal.js
+++ b/js/src/forum/components/SuspendUserModal.js
@@ -43,6 +43,9 @@ export default class SuspendUserModal extends Modal {
         <div className="Form">
           <div className="Form-group">
             <label>{app.translator.trans('flarum-suspend.forum.suspend_user.status_heading')}</label>
+            <div>{this.radioItems().toArray()}</div>
+          </div>
+          <div className='Form-group'>
             <div>{this.formItems().toArray()}</div>
           </div>
 
@@ -56,7 +59,7 @@ export default class SuspendUserModal extends Modal {
     );
   }
 
-  formItems() {
+  radioItems() {
     const items = new ItemList();
 
     items.add(
@@ -103,6 +106,12 @@ export default class SuspendUserModal extends Modal {
       80
     );
 
+    return items;
+  }
+
+  formItems() {
+    const items = new ItemList();
+
     items.add(
       'reason',
       <label>
@@ -114,7 +123,7 @@ export default class SuspendUserModal extends Modal {
           rows="2"
         />
       </label>,
-      70
+      90
     );
 
     items.add(
@@ -128,7 +137,7 @@ export default class SuspendUserModal extends Modal {
           rows="2"
         />
       </label>,
-      60
+      80
     );
 
     return items;

--- a/js/src/forum/components/SuspendUserModal.js
+++ b/js/src/forum/components/SuspendUserModal.js
@@ -109,42 +109,36 @@ export default class SuspendUserModal extends Modal {
   formItems() {
     const items = new ItemList();
 
-    items.add(
-      'radioItems',
-      <div className='Form-group'>
-        {this.radioItems().toArray()}
-      </div>,
-      100
-    );
+    items.add('radioItems', <div className="Form-group">{this.radioItems().toArray()}</div>, 100);
 
     items.add(
       'reason',
-      <div className='Form-group'>
+      <div className="Form-group">
         <label>
-        {app.translator.trans('flarum-suspend.forum.suspend_user.reason')}
-        <textarea
-          className="FormControl"
-          bidi={this.reason}
-          placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')}
-          rows="2"
-        />
-      </label>
+          {app.translator.trans('flarum-suspend.forum.suspend_user.reason')}
+          <textarea
+            className="FormControl"
+            bidi={this.reason}
+            placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')}
+            rows="2"
+          />
+        </label>
       </div>,
       90
     );
 
     items.add(
       'message',
-      <div className='Form-group'>
+      <div className="Form-group">
         <label>
-        {app.translator.trans('flarum-suspend.forum.suspend_user.display_message')}
-        <textarea
-          className="FormControl"
-          bidi={this.message}
-          placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')}
-          rows="2"
-        />
-      </label>
+          {app.translator.trans('flarum-suspend.forum.suspend_user.display_message')}
+          <textarea
+            className="FormControl"
+            bidi={this.message}
+            placeholder={app.translator.trans('flarum-suspend.forum.suspend_user.placeholder_optional')}
+            rows="2"
+          />
+        </label>
       </div>,
       80
     );

--- a/js/src/forum/components/SuspensionInfoModal.js
+++ b/js/src/forum/components/SuspensionInfoModal.js
@@ -1,0 +1,43 @@
+import app from 'flarum/forum/app';
+import Modal from 'flarum/common/components/Modal';
+import Button from 'flarum/common/components/Button';
+import fullTime from 'flarum/common/helpers/fullTime';
+
+export default class ResultsModal extends Modal {
+  oninit(vnode) {
+    super.oninit(vnode);
+
+    this.message = this.attrs.message;
+    this.until = this.attrs.until;
+  }
+
+  className() {
+    return 'SuspendInfoModal Modal';
+  }
+
+  title() {
+    return app.translator.trans('flarum-suspend.forum.infomodal.title');
+  }
+
+  content() {
+    const timespan =
+      this.until.getFullYear() === 2038
+        ? app.translator.trans('flarum-suspend.forum.infomodal.indefinite')
+        : app.translator.trans('flarum-suspend.forum.infomodal.limited', { date: fullTime(this.until) });
+
+    return (
+      <div className="Modal-body">
+        <div className="Form Form--centered">
+          <p className="helpText">{this.message}</p>
+          <p className="helpText">{timespan}</p>
+
+          <div className="Form-group">
+            <Button className="Button Button--primary Button--block" onclick={this.hide.bind(this)}>
+              {app.translator.trans('flarum-suspend.forum.infomodal.dismiss_button')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/js/src/forum/components/SuspensionInfoModal.js
+++ b/js/src/forum/components/SuspensionInfoModal.js
@@ -2,7 +2,7 @@ import app from 'flarum/forum/app';
 import Modal from 'flarum/common/components/Modal';
 import Button from 'flarum/common/components/Button';
 import fullTime from 'flarum/common/helpers/fullTime';
-import { isPermanentSuspensionDate } from '../helpers/suspensionHelper';
+import { isPermanentSuspensionDate, localStorageKey } from '../helpers/suspensionHelper';
 
 export default class SuspensionInfoModal extends Modal {
   oninit(vnode) {
@@ -39,5 +39,10 @@ export default class SuspensionInfoModal extends Modal {
         </div>
       </div>
     );
+  }
+
+  hide() {
+    localStorage.setItem(localStorageKey(), this.attrs.until);
+    this.attrs.state.close();
   }
 }

--- a/js/src/forum/components/SuspensionInfoModal.js
+++ b/js/src/forum/components/SuspensionInfoModal.js
@@ -2,6 +2,7 @@ import app from 'flarum/forum/app';
 import Modal from 'flarum/common/components/Modal';
 import Button from 'flarum/common/components/Button';
 import fullTime from 'flarum/common/helpers/fullTime';
+import { isPermanentSuspensionDate } from '../helpers/suspensionHelper';
 
 export default class SuspensionInfoModal extends Modal {
   oninit(vnode) {
@@ -21,7 +22,7 @@ export default class SuspensionInfoModal extends Modal {
 
   content() {
     const timespan =
-      this.until.getFullYear() === 2038
+      isPermanentSuspensionDate(new Date(this.until))
         ? app.translator.trans('flarum-suspend.forum.suspension-info.indefinite')
         : app.translator.trans('flarum-suspend.forum.suspension-info.limited', { date: fullTime(this.until) });
 

--- a/js/src/forum/components/SuspensionInfoModal.js
+++ b/js/src/forum/components/SuspensionInfoModal.js
@@ -42,7 +42,7 @@ export default class SuspensionInfoModal extends Modal {
   }
 
   hide() {
-    localStorage.setItem(localStorageKey(), this.attrs.until);
+    localStorage.setItem(localStorageKey(), this.attrs.until.getTime());
     this.attrs.state.close();
   }
 }

--- a/js/src/forum/components/SuspensionInfoModal.js
+++ b/js/src/forum/components/SuspensionInfoModal.js
@@ -21,10 +21,9 @@ export default class SuspensionInfoModal extends Modal {
   }
 
   content() {
-    const timespan =
-      isPermanentSuspensionDate(new Date(this.until))
-        ? app.translator.trans('flarum-suspend.forum.suspension_info.indefinite')
-        : app.translator.trans('flarum-suspend.forum.suspension_info.limited', { date: fullTime(this.until) });
+    const timespan = isPermanentSuspensionDate(new Date(this.until))
+      ? app.translator.trans('flarum-suspend.forum.suspension_info.indefinite')
+      : app.translator.trans('flarum-suspend.forum.suspension_info.limited', { date: fullTime(this.until) });
 
     return (
       <div className="Modal-body">

--- a/js/src/forum/components/SuspensionInfoModal.js
+++ b/js/src/forum/components/SuspensionInfoModal.js
@@ -17,14 +17,14 @@ export default class SuspensionInfoModal extends Modal {
   }
 
   title() {
-    return app.translator.trans('flarum-suspend.forum.suspension-info.title');
+    return app.translator.trans('flarum-suspend.forum.suspension_info.title');
   }
 
   content() {
     const timespan =
       isPermanentSuspensionDate(new Date(this.until))
-        ? app.translator.trans('flarum-suspend.forum.suspension-info.indefinite')
-        : app.translator.trans('flarum-suspend.forum.suspension-info.limited', { date: fullTime(this.until) });
+        ? app.translator.trans('flarum-suspend.forum.suspension_info.indefinite')
+        : app.translator.trans('flarum-suspend.forum.suspension_info.limited', { date: fullTime(this.until) });
 
     return (
       <div className="Modal-body">
@@ -34,7 +34,7 @@ export default class SuspensionInfoModal extends Modal {
 
           <div className="Form-group">
             <Button className="Button Button--primary Button--block" onclick={this.hide.bind(this)}>
-              {app.translator.trans('flarum-suspend.forum.suspension-info.dismiss_button')}
+              {app.translator.trans('flarum-suspend.forum.suspension_info.dismiss_button')}
             </Button>
           </div>
         </div>

--- a/js/src/forum/components/SuspensionInfoModal.js
+++ b/js/src/forum/components/SuspensionInfoModal.js
@@ -3,7 +3,7 @@ import Modal from 'flarum/common/components/Modal';
 import Button from 'flarum/common/components/Button';
 import fullTime from 'flarum/common/helpers/fullTime';
 
-export default class ResultsModal extends Modal {
+export default class SuspensionInfoModal extends Modal {
   oninit(vnode) {
     super.oninit(vnode);
 
@@ -12,7 +12,7 @@ export default class ResultsModal extends Modal {
   }
 
   className() {
-    return 'SuspendInfoModal Modal';
+    return 'SuspensionInfoModal Modal';
   }
 
   title() {

--- a/js/src/forum/components/SuspensionInfoModal.js
+++ b/js/src/forum/components/SuspensionInfoModal.js
@@ -16,14 +16,14 @@ export default class SuspensionInfoModal extends Modal {
   }
 
   title() {
-    return app.translator.trans('flarum-suspend.forum.infomodal.title');
+    return app.translator.trans('flarum-suspend.forum.suspension-info.title');
   }
 
   content() {
     const timespan =
       this.until.getFullYear() === 2038
-        ? app.translator.trans('flarum-suspend.forum.infomodal.indefinite')
-        : app.translator.trans('flarum-suspend.forum.infomodal.limited', { date: fullTime(this.until) });
+        ? app.translator.trans('flarum-suspend.forum.suspension-info.indefinite')
+        : app.translator.trans('flarum-suspend.forum.suspension-info.limited', { date: fullTime(this.until) });
 
     return (
       <div className="Modal-body">
@@ -33,7 +33,7 @@ export default class SuspensionInfoModal extends Modal {
 
           <div className="Form-group">
             <Button className="Button Button--primary Button--block" onclick={this.hide.bind(this)}>
-              {app.translator.trans('flarum-suspend.forum.infomodal.dismiss_button')}
+              {app.translator.trans('flarum-suspend.forum.suspension-info.dismiss_button')}
             </Button>
           </div>
         </div>

--- a/js/src/forum/components/UserSuspendedNotification.js
+++ b/js/src/forum/components/UserSuspendedNotification.js
@@ -1,5 +1,6 @@
 import app from 'flarum/forum/app';
 import Notification from 'flarum/components/Notification';
+import { isPermanentSuspensionDate } from '../helpers/suspensionHelper';
 
 export default class UserSuspendedNotification extends Notification {
   icon() {
@@ -15,7 +16,9 @@ export default class UserSuspendedNotification extends Notification {
     const suspendedUntil = notification.content();
     const timeReadable = dayjs(suspendedUntil).from(notification.createdAt(), true);
 
-    return app.translator.trans('flarum-suspend.forum.notifications.user_suspended_text', {
+    return isPermanentSuspensionDate(suspendedUntil)
+      ? app.translator.trans('flarum-suspend.forum.notifications.user_suspended_indefinite_text')
+      : app.translator.trans('flarum-suspend.forum.notifications.user_suspended_text', {
       timeReadable,
     });
   }

--- a/js/src/forum/components/UserSuspendedNotification.js
+++ b/js/src/forum/components/UserSuspendedNotification.js
@@ -1,3 +1,4 @@
+import app from 'flarum/forum/app';
 import Notification from 'flarum/components/Notification';
 
 export default class UserSuspendedNotification extends Notification {

--- a/js/src/forum/components/UserSuspendedNotification.js
+++ b/js/src/forum/components/UserSuspendedNotification.js
@@ -19,7 +19,7 @@ export default class UserSuspendedNotification extends Notification {
     return isPermanentSuspensionDate(suspendedUntil)
       ? app.translator.trans('flarum-suspend.forum.notifications.user_suspended_indefinite_text')
       : app.translator.trans('flarum-suspend.forum.notifications.user_suspended_text', {
-      timeReadable,
-    });
+          timeReadable,
+        });
   }
 }

--- a/js/src/forum/components/UserUnsuspendedNotification.js
+++ b/js/src/forum/components/UserUnsuspendedNotification.js
@@ -1,3 +1,4 @@
+import app from 'flarum/forum/app';
 import Notification from 'flarum/components/Notification';
 
 export default class UserUnsuspendedNotification extends Notification {

--- a/js/src/forum/helpers/suspensionHelper.ts
+++ b/js/src/forum/helpers/suspensionHelper.ts
@@ -1,0 +1,12 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+
+export function getPermanentSuspensionDate(): Date {
+  return new Date('2038-01-01');
+}
+
+export function isPermanentSuspensionDate(date: Date): boolean {
+  return dayjs.utc(date).isSame('2038-01-01');
+}

--- a/js/src/forum/helpers/suspensionHelper.ts
+++ b/js/src/forum/helpers/suspensionHelper.ts
@@ -10,3 +10,7 @@ export function getPermanentSuspensionDate(): Date {
 export function isPermanentSuspensionDate(date: Date): boolean {
   return dayjs.utc(date).isSame(dayjs.utc('2038-01-01'));
 }
+
+export function localStorageKey(): string {
+  return 'flarum-suspend.acknowledge-suspension';
+}

--- a/js/src/forum/helpers/suspensionHelper.ts
+++ b/js/src/forum/helpers/suspensionHelper.ts
@@ -8,5 +8,5 @@ export function getPermanentSuspensionDate(): Date {
 }
 
 export function isPermanentSuspensionDate(date: Date): boolean {
-  return dayjs.utc(date).isSame('2038-01-01');
+  return dayjs.utc(date).isSame(dayjs.utc('2038-01-01'));
 }

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -9,6 +9,7 @@ import User from 'flarum/models/User';
 import SuspendUserModal from './components/SuspendUserModal';
 import UserSuspendedNotification from './components/UserSuspendedNotification';
 import UserUnsuspendedNotification from './components/UserUnsuspendedNotification';
+import checkForSuspension from './checkForSuspension';
 
 app.initializers.add('flarum-suspend', () => {
   app.notificationComponents.userSuspended = UserSuspendedNotification;
@@ -16,6 +17,8 @@ app.initializers.add('flarum-suspend', () => {
 
   User.prototype.canSuspend = Model.attribute('canSuspend');
   User.prototype.suspendedUntil = Model.attribute('suspendedUntil', Model.transformDate);
+  User.prototype.suspendReason = Model.attribute('suspendReason');
+  User.prototype.suspendMessage = Model.attribute('suspendMessage');
 
   extend(UserControls, 'moderationControls', (items, user) => {
     if (user.canSuspend()) {
@@ -46,4 +49,12 @@ app.initializers.add('flarum-suspend', () => {
       );
     }
   });
+
+  checkForSuspension();
 });
+
+// Expose compat API
+import suspendCompat from './compat';
+import { compat } from '@flarum/core/forum';
+
+Object.assign(compat, suspendCompat);

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -13,16 +13,17 @@ flarum-suspend:
 
   # Translations in this namespace are used by the forum user interface.
   forum:
-    infomodal:
-      dismiss_button: Dismiss
-      indefinite: This is an indefinite suspension
-      limited: "This suspension will be in force until {date}"
-      title: This account is suspended
-
     # These translations are used in the suspension notifications
     notifications:
       user_suspended_text: "You have been suspended for {timeReadable}"
       user_unsuspended_text: You have been unsuspended
+
+    # These translations are used for the suspension reason informational modal to the suspended user.
+    suspension-info:
+      dismiss_button: Dismiss
+      indefinite: This is an indefinite suspension
+      limited: "This suspension will be in force until {date}"
+      title: This account is suspended
 
     # These translations are used in the Suspend User modal dialog (admin function).
     suspend_user:

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -31,6 +31,7 @@ flarum-suspend:
       limited_time_days_text: " days"
       limited_time_label: Suspended for a limited time...
       not_suspended_label: Not suspended
+      placeholder_optional: Optional
       reason: Reason for suspension
       status_heading: Suspension Status
       submit_button: => core.ref.save_changes

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -16,6 +16,7 @@ flarum-suspend:
     # These translations are used in the suspension notifications
     notifications:
       user_suspended_text: "You have been suspended for {timeReadable}"
+      user_suspended_indefinite_text: You have been suspended indefinitely
       user_unsuspended_text: You have been unsuspended
 
     # These translations are used for the suspension reason informational modal to the suspended user.

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -19,7 +19,7 @@ flarum-suspend:
       user_unsuspended_text: You have been unsuspended
 
     # These translations are used for the suspension reason informational modal to the suspended user.
-    suspension-info:
+    suspension_info:
       dismiss_button: Dismiss
       indefinite: This is an indefinite suspension
       limited: "This suspension will be in force until {date}"

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -13,6 +13,12 @@ flarum-suspend:
 
   # Translations in this namespace are used by the forum user interface.
   forum:
+    infomodal:
+      dismiss_button: Dismiss
+      indefinite: This is an indefinite suspension
+      limited: "This suspension will be in force until {date}"
+      title: This account is suspended
+
     # These translations are used in the suspension notifications
     notifications:
       user_suspended_text: "You have been suspended for {timeReadable}"
@@ -20,10 +26,12 @@ flarum-suspend:
 
     # These translations are used in the Suspend User modal dialog (admin function).
     suspend_user:
+      display_message: Display message for user
       indefinitely_label: Suspended indefinitely
       limited_time_days_text: " days"
       limited_time_label: Suspended for a limited time...
       not_suspended_label: Not suspended
+      reason: Reason for suspension
       status_heading: Suspension Status
       submit_button: => core.ref.save_changes
       title: "Suspend {username}"
@@ -35,3 +43,25 @@ flarum-suspend:
     # These translations are found on the user profile page (admin function).
     user_controls:
       suspend_button: Suspend
+
+  # Translations in this namespace are used by suspension email notifications
+  email:
+    suspended:
+      subject: Your account has been suspended
+      body: |
+        Hey {recipient_display_name},
+
+        You have been suspended for the following reason:
+
+        ---
+        {suspension_message}
+        ---
+
+    unsuspended:
+      subject: Your account has been unsuspended
+      body: |
+        Hey {recipient_display_name},
+
+        You have been unsuspended. You can head back to the forum by clicking on the following link:
+
+        {forum_url}

--- a/migrations/2021_10_27_000000_add_suspend_reason_and_message.php
+++ b/migrations/2021_10_27_000000_add_suspend_reason_and_message.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('users', [
+    'suspend_reason' => ['text', 'nullable' => true],
+    'suspend_message' => ['text', 'nullable' => true]
+]);

--- a/src/AddUserSuspendAttributes.php
+++ b/src/AddUserSuspendAttributes.php
@@ -20,7 +20,6 @@ class AddUserSuspendAttributes
         $canSuspend = $serializer->getActor()->can('suspend', $user);
 
         if ($canSuspend) {
-            $attributes['suspendedUntil'] = $serializer->formatDate($user->suspended_until);
             $attributes['suspendReason'] = $user->suspend_reason;
             $attributes['suspendMessage'] = $user->suspend_message;
         }

--- a/src/AddUserSuspendAttributes.php
+++ b/src/AddUserSuspendAttributes.php
@@ -21,13 +21,10 @@ class AddUserSuspendAttributes
 
         if ($canSuspend) {
             $attributes['suspendReason'] = $user->suspend_reason;
-            $attributes['suspendMessage'] = $user->suspend_message;
         }
 
         if ($serializer->getActor()->id === $user->id || $canSuspend) {
-            if (! empty($user->suspend_message)) {
-                $attributes['suspendMessage'] = $user->suspend_message;
-            }
+            $attributes['suspendMessage'] = $user->suspend_message;
             $attributes['suspendedUntil'] = $serializer->formatDate($user->suspended_until);
         }
 

--- a/src/AddUserSuspendAttributes.php
+++ b/src/AddUserSuspendAttributes.php
@@ -21,6 +21,15 @@ class AddUserSuspendAttributes
 
         if ($canSuspend) {
             $attributes['suspendedUntil'] = $serializer->formatDate($user->suspended_until);
+            $attributes['suspendReason'] = $user->suspend_reason;
+            $attributes['suspendMessage'] = $user->suspend_message;
+        }
+
+        if ($serializer->getActor()->id === $user->id || $canSuspend) {
+            if (! empty($user->suspend_message)) {
+                $attributes['suspendMessage'] = $user->suspend_message;
+            }
+            $attributes['suspendedUntil'] = $serializer->formatDate($user->suspended_until);
         }
 
         $attributes['canSuspend'] = $canSuspend;

--- a/src/Listener/SaveSuspensionToDatabase.php
+++ b/src/Listener/SaveSuspensionToDatabase.php
@@ -53,13 +53,12 @@ class SaveSuspensionToDatabase
 
             $actor->assertCan('suspend', $user);
 
-            $user->suspended_until = null;
-
             if ($attributes['suspendedUntil']) {
                 $user->suspended_until = new DateTime($attributes['suspendedUntil']);
                 $user->suspend_reason = empty($attributes['suspendReason']) ? null : $attributes['suspendReason'];
                 $user->suspend_message = empty($attributes['suspendMessage']) ? null : $attributes['suspendMessage'];
             } else {
+                $user->suspended_until = null;
                 $user->suspend_reason = null;
                 $user->suspend_message = null;
             }

--- a/src/Listener/SaveSuspensionToDatabase.php
+++ b/src/Listener/SaveSuspensionToDatabase.php
@@ -53,11 +53,18 @@ class SaveSuspensionToDatabase
 
             $actor->assertCan('suspend', $user);
 
-            $user->suspended_until = $attributes['suspendedUntil']
-                ? new DateTime($attributes['suspendedUntil'])
-                : null;
+            $user->suspended_until = null;
 
-            if ($user->isDirty('suspended_until')) {
+            if ($attributes['suspendedUntil']) {
+                $user->suspended_until = new DateTime($attributes['suspendedUntil']);
+                $user->suspend_reason = empty($attributes['suspendReason']) ? null : $attributes['suspendReason'];
+                $user->suspend_message = empty($attributes['suspendMessage']) ? null : $attributes['suspendMessage'];
+            } else {
+                $user->suspend_reason = null;
+                $user->suspend_message = null;
+            }
+
+            if ($user->isDirty(['suspended_until', 'suspend_reason', 'suspend_message'])) {
                 $this->events->dispatch(
                     $user->suspended_until === null ?
                         new Unsuspended($user, $actor) :

--- a/src/Notification/UserSuspendedBlueprint.php
+++ b/src/Notification/UserSuspendedBlueprint.php
@@ -10,9 +10,11 @@
 namespace Flarum\Suspend\Notification;
 
 use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\MailableInterface;
 use Flarum\User\User;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
-class UserSuspendedBlueprint implements BlueprintInterface
+class UserSuspendedBlueprint implements BlueprintInterface, MailableInterface
 {
     /**
      * @var User
@@ -65,5 +67,21 @@ class UserSuspendedBlueprint implements BlueprintInterface
     public static function getSubjectModel()
     {
         return User::class;
+    }
+
+        /**
+     * {@inheritdoc}
+     */
+    public function getEmailView()
+    {
+        return ['text' => 'flarum-suspend::emails.suspended'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEmailSubject(TranslatorInterface $translator)
+    {
+        return $translator->trans('flarum-suspend.email.suspended.subject');
     }
 }

--- a/src/Notification/UserSuspendedBlueprint.php
+++ b/src/Notification/UserSuspendedBlueprint.php
@@ -69,7 +69,7 @@ class UserSuspendedBlueprint implements BlueprintInterface, MailableInterface
         return User::class;
     }
 
-        /**
+    /**
      * {@inheritdoc}
      */
     public function getEmailView()

--- a/src/Notification/UserUnsuspendedBlueprint.php
+++ b/src/Notification/UserUnsuspendedBlueprint.php
@@ -10,9 +10,12 @@
 namespace Flarum\Suspend\Notification;
 
 use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\MailableInterface;
 use Flarum\User\User;
+use Illuminate\Support\Carbon;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
-class UserUnsuspendedBlueprint implements BlueprintInterface
+class UserUnsuspendedBlueprint implements BlueprintInterface, MailableInterface
 {
     /**
      * @var User
@@ -48,7 +51,7 @@ class UserUnsuspendedBlueprint implements BlueprintInterface
      */
     public function getData()
     {
-        return null;
+        return Carbon::now();
     }
 
     /**
@@ -65,5 +68,21 @@ class UserUnsuspendedBlueprint implements BlueprintInterface
     public static function getSubjectModel()
     {
         return User::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEmailView()
+    {
+        return ['text' => 'flarum-suspend::emails.unsuspended'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEmailSubject(TranslatorInterface $translator)
+    {
+        return $translator->trans('flarum-suspend.email.unsuspended.subject');
     }
 }

--- a/views/emails/suspended.blade.php
+++ b/views/emails/suspended.blade.php
@@ -1,0 +1,4 @@
+{!! $translator->trans('flarum-suspend.email.suspended.body', [
+'{recipient_display_name}' => $user->display_name,
+'{suspension_message}' => $blueprint->user->suspend_message,
+]) !!}

--- a/views/emails/unsuspended.blade.php
+++ b/views/emails/unsuspended.blade.php
@@ -1,0 +1,4 @@
+{!! $translator->trans('flarum-suspend.email.unsuspended.body', [
+'{recipient_display_name}' => $user->display_name,
+'{forum_url}' => $url->to('forum')->base(),
+]) !!}


### PR DESCRIPTION
Addresses https://github.com/flarum/core/issues/1447

Recreation of https://github.com/flarum/suspend/pull/34, before that got polluted

- [x] Expand `SuspendUserModal` to include two new optional fields: reason (for moderator use) and message (for display to the suspended user
- [x] Display a modal to a suspended user, displaying the message entered by the moderator, and the length of the suspension
- [x] Move `Form-group` components to an `ItemList` for extensibility
- [x] `compat` exports
- [x] Expand notification blueprints to include email notifications of suspension/unsuspension, including the suspension message

![image](https://user-images.githubusercontent.com/16573496/108422468-7f049180-722e-11eb-84a8-8c057ef0458e.png)

![image](https://user-images.githubusercontent.com/16573496/108403791-0514de00-7217-11eb-9124-fd84a15934a1.png)

![image](https://user-images.githubusercontent.com/16573496/108403706-e9113c80-7216-11eb-834f-c3d163563044.png)
