### PR TITLE
fix: Minor JS error when user is not suspended

### DIFF
--- a/js/src/forum/checkForSuspension.ts
+++ b/js/src/forum/checkForSuspension.ts
@@ -7,7 +7,7 @@ export default function () {
     if (app.session.user) {
       const message = app.session.user.suspendMessage();
       const until = app.session.user.suspendedUntil();
-      const alreadyDisplayed = localStorage.getItem(localStorageKey()) === until.getTime().toString();
+      const alreadyDisplayed = localStorage.getItem(localStorageKey()) === until?.getTime().toString();
 
       if (message && !alreadyDisplayed) {
         app.modal.show(SuspensionInfoModal, { message, until });


### PR DESCRIPTION
**Changes proposed in this pull request:**
When the logged in user is not suspended, the following console error is present, because suspendedUntil is null.

```
Uncaught TypeError: Cannot read properties of null (reading 'getTime')
    at checkForSuspension.ts:10
```